### PR TITLE
fix: og 이미지 url 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     description: desc,
     images: [
       {
-        url: "https://call22nd.works/images/opengraph-image.png",
+        url: "./opengraph-image.png",
         width: 1200,
         height: 630,
         alt: "우리동네 국회의원들에게 강간죄 개정&여가부 유지할 건지 물어보러 가기",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,10 +20,10 @@ export const metadata: Metadata = {
     description: desc,
     images: [
       {
-        url: "./opengraph-image.png",
+        url: "https://call22nd.works/opengraph-image.png",
         width: 1200,
         height: 630,
-        alt: "우리동네 국회의원들에게 강간죄 개정&여가부 유지할 건지 물어보러 가기",
+        alt: "우리동네 국회의원들에게 강간죄 개정 & 여가부 유지할 건지 물어보러 가기",
       }
     ],
   }


### PR DESCRIPTION
이전 `layout.tsx`의 `Metadata opengraph-image url`은 404 에러가 떴습니다.
url을 변경하니 잘 나옵니다.