### PR TITLE
fix: 질문 수에 관련된 변수를 바로잡음

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -23,7 +23,7 @@ const Stats = () => {
 
     return (
         <p>
-            현재까지 <em>{stats ? stats.responses : 0}개</em>의 질문과<br />
+            현재까지 <em>{stats ? stats.requests : 0}개</em>의 질문과<br />
             함께하고 있습니다.
         </p>
     )


### PR DESCRIPTION
- 현재 메인 페이지에서는 메일이 나간 수를 집계하고 있습니다.
- 메일이 나간 수가 아니라 사용자들의 질문 수를 집계하면 좋을 것 같습니다.